### PR TITLE
Fix dependencies and default user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 This file is used to list changes made in each version of the qmk_cookbook cookbook.
 
-## [0.2.0] - TBD
+## [0.2.1] - 2019-03-01
+
+## [0.2.0] - 2019-02-10
 
 ### Added
 - `users` recipe for creating an ubuntu user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the qmk_cookbook cookb
 
 ## [0.2.1] - 2019-03-01
 
+## Fixed
+- Change login user to `vagrant` to make it easier to create firmware files without logging into another user. 
+- Get rid of execute statement to run `qmk_install.sh` and just use `apt_package` resource. 
+
 ## [0.2.0] - 2019-02-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 ## Attributes
 
-- `default['qmk']['admin_user'] = 'mechmerlin'`
-- `default['qmk']['admin_passwd'] = 'password'`
-- `default['qmk']['github_user'] = 'mechmerlin'`
+- `default['qmk']['admin_user'] = 'vagrant'`
+- `default['qmk']['admin_passwd'] = 'vagrant'`
+- `default['qmk']['github_user'] = 'qmk'`
 
 ## Recipes
 
@@ -70,6 +70,6 @@ You may replace `default-ubuntu-1604` with your target.
 
 7. Run a `kitchen verify` command to check that all packages have been installed correctly.
 
-8. Run a `kitchen login` command to log into the `VM` and be sure to `ssh username@localhost`, in this case the username should be mechmerlin. The other option is to open up virtualbox and open up the newly created instance and run Ubuntu in a VM. 
+8. Run a `kitchen login` command to log into the `VM` and be sure to `ssh username@localhost`, in this case the username should be `vagrant`. The other option is to open up virtualbox and open up the newly created instance and run Ubuntu in a VM. 
 
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,21 @@
-default['qmk']['admin_user'] = 'mechmerlin'
-default['qmk']['admin_passwd'] = 'password'
-default['qmk']['github_user'] = 'mechmerlin'
+default['qmk']['admin_user'] = 'vagrant'
+default['qmk']['admin_passwd'] = 'vagrant'
+default['qmk']['github_user'] = 'qmk'
+
+default['qmk']['ubuntu_pkgs'] = [
+  'build-essential',
+  'avr-libc',
+  'binutils-arm-none-eabi',
+  'binutils-avr',
+  'dfu-programmer',
+  'dfu-util',
+  'diffutils',
+  'gcc',
+  'gcc-arm-none-eabi',
+  'gcc-avr',
+  'git',
+  'libnewlib-arm-none-eabi',
+  'unzip',
+  'zip',
+  'wget',
+]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mechmerlin@gmail.com'
 license 'All Rights Reserved'
 description 'Installs/Configures qmk_cookbook'
 long_description 'Installs/Configures qmk_cookbook'
-version '0.2.0'
+version '0.2.1'
 chef_version '>= 14.0' if respond_to?(:chef_version)
 
 issues_url 'https://github.com/mechmerlin/qmk_cookbook/issues'

--- a/recipes/directories.rb
+++ b/recipes/directories.rb
@@ -1,4 +1,4 @@
-user = node['qmk']['admin_user']
+user = 'vagrant'
 
 users_dir = if platform?('mac_os_x')
               '/Users'

--- a/recipes/firmware.rb
+++ b/recipes/firmware.rb
@@ -1,4 +1,4 @@
-user = node['qmk']['admin_user']
+user = 'vagrant'
 
 users_dir = if platform?('mac_os_x')
               '/Users'
@@ -27,7 +27,8 @@ git 'clone qmk_firmware fork from github' do
   action :sync
 end
 
-execute 'install dependencies' do
-  cwd ::File.join(qmk_fw_dir, 'util')
-  command './qmk_install.sh'
+apt_pkgs = node['qmk']['ubuntu_pkgs']
+
+apt_pkgs.each do |package|
+  apt_package package
 end


### PR DESCRIPTION
## [0.2.1] - 2019-03-01

 ## Fixed
- Change login user to `vagrant` to make it easier to create firmware files without logging into another user. 
- Get rid of execute statement to run `qmk_install.sh` and just use `apt_package` resource. 